### PR TITLE
English typos proposal

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,30 +1,30 @@
 ## Digest
-* from Thursday, june 16th to Sunday, june 19th 
-* up to 20 developpers
-* A cottage in the french Alps
-* No program.
-* No organiser.
-* 160 euros for food and bed for the week.
-* Registration: [https://dos2016.eventbrite.co.uk](https://dos2016.eventbrite.co.uk)
+* from Thursday, June 16th to Sunday, June 19th 
+* up to 20 developers
+* A cottage in the French Alps
+* No program
+* No organiser
+* 160 euros for food and bed for the week
+* Registration: [https://dos2016.eventbrite.co.uk](https://dos2016.eventbrite.co.uk).
 
 ## FAQ
-*The event will be made by those who will be there*
+*The event will be made by those who will be there*.
 
 #### What is DevOpenSud?
 
-Somewhere in the Alps, in the middle of nowhere some developpers gather in a cottage to talk, code, walk, pair, collaborate, play, cook, do things...
+Somewhere in the Alps, in the middle of nowhere some developers gathered in a cottage to talk, code, walk, pair, collaborate, play, cook, do things...
 
 #### Who organise that thing?
 
-There are ``s/not really/really no/`` organisers.
+There are `s/not really/really no/` organisers.
 
-#### How much does it costs?
+#### How much does it cost?
 
 We don't know exactly yet, but it won't be above 160 euros (tax excl).
 
 #### What is included for that price?
 
-From Thursday, june 16th in the morning to sunday, june 19th: all your meal and bed.
+From Thursday, June 16th in the morning to Sunday, June 19th: all your meals and bed.
 
 #### Can I come to work during the day and play with you at night?
 
@@ -40,46 +40,46 @@ Yes, we can do that.
 
 #### Where do I sign?
 
-Registration are here: [https://dos2016.eventbrite.co.uk](https://dos2016.eventbrite.co.uk).
+Registration is here: [https://dos2016.eventbrite.co.uk](https://dos2016.eventbrite.co.uk).
 
 #### How many people will be there?
 
 Maybe 10, maximum 20, probably around 15.
 
-#### Is there some carpooling planned to go to the event?
+#### Is there some carpooling planned to reach the event?
 
-Well, ``we`` won't plan anything, but ``you`` can use the mailing list [devopensud-2016@googlegroups.com](https://groups.google.com/d/forum/devopensud-2016) to organise it :)
+Well, `we` won't plan anything, but `you` can use the mailing list [devopensud-2016@googlegroups.com](https://groups.google.com/d/forum/devopensud-2016) to organise it :)
 
 #### How are the room?
 
-There are 8 rooms, from 1 to 9 beds. Some are bunk beds, some are single bed or double bed. [Some pictures of the rooms](http://www.grangedebrudour.com/crbst_1.html)
+There are 8 rooms, from 1 to 9 beds. Some are bunk beds, some are single bed or double bed. [Some pictures of the rooms](http://www.grangedebrudour.com/crbst_1.html).
 
 #### Can I have a room with no snorer?
 
-You probably could find a way to organize a room with no snorer. But, maybe it could be a good idea to come with earplugs :)
+You probably could find a way to organise a room with no snorer. But it may be a good idea to come with earplugs :)
 
 #### What will we eat?
 
-It is not decide yet. But if you have some food constraints (no gluten, allergies, vegan, ...) please, tell us as soon as possible so we can take care of it.
+It is not decided yet. But if you have some food constraints (no gluten, allergies, vegan, ...) please, tell us as soon as possible so we can consider it.
 
 #### By the way, where is it?
 
-> DevOpenSud 2016 will be held at "La grange du Brudour" near Aspres les Corps (05800) in France. More info on the website of "[La grange du Brudour](http://www.grangedebrudour.com/)" (in french)
+> DevOpenSud 2016 will be held at "La grange du Brudour" near Aspres les Corps (05800) in France. More infos on the website of "[La grange du Brudour](http://www.grangedebrudour.com/)" (in French).
 
 #### What if I have a question?
 
-You can contact Antoine - [@avernois](http://twitter.com/avernois) - or Stéphane - [@langlois_s](http://twitter.com/langlois_s)
+You can contact Antoine - [@avernois](http://twitter.com/avernois) - or Stéphane - [@langlois_s](http://twitter.com/langlois_s).
 
-You can also use the IRC channel ##devopensud on freenode, or subscribe to the mailing-list: [devopensud-2016@googlegroups.com](https://groups.google.com/d/forum/devopensud-2016)
+You can also use the IRC channel _##devopensud_ on freenode, or subscribe to the mailing-list: [devopensud-2016@googlegroups.com](https://groups.google.com/d/forum/devopensud-2016).
 
-## But your english is awfull?
+## But your English is awful?
 
-Yes, we know. We are french. But we will be very happy if you can help us improve this page (and our bad english): [https://github.com/devopensud/devopensud.github.io]
+Yes, we know. We are French. But we will be very happy if you help us improve this page (and our bad English): [https://github.com/devopensud/devopensud.github.io].
 
-## You will maximize your chance of satisfaction if
+## You will maximise your chances of satisfaction if
 
-* you organize yourself and don't rely only on the non-organisers
+* you organise yourself and don't rely only on the non-organisers
 * you follow the [law of two feet](http://en.wikipedia.org/wiki/Open_Space_Technology#Law_of_two_feet)
-* you know that those who will be there will be the right ones
+* you know that those who will be there will be the right ones.
 
 <script src="static/js/mdwrangler.js"></script>


### PR DESCRIPTION
Suggest an adapation about English language.

- cultures and languages – event as adjective –,  days of the week, months, … are _C_apitalised in English (as opposed as in French)
- lists don't take a final point except for the last bullet
- _ise_ vs _ize_ suffix: both are correct. The 1st is British English and the 2nd is US English. Pick one and stick to it all over the document.

Some extra changes that might be more be considered as usage proposal than actual mistakes.